### PR TITLE
rename project slug in config file

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -22,7 +22,7 @@ const siteConfig = {
   url: 'https://legend.finos.org',
   baseUrl: '/',
   // For publishing to GitHub pages
-  projectName: 'alloy',
+  projectName: 'legend',
   organizationName: 'finos',
   // For no header links in the top nav bar -> headerLinks: [],
   headerLinks: [


### PR DESCRIPTION
When i forked legend to try and fix an issue over on ODP https://github.com/finos/open-developer-platform/issues/181

I found the Github Action was not working, i think it was because of the project slug(name) in the config file.

Changing this on my fork allows the action to pass.

You can see the error here: https://github.com/adamj-codethink/legend/pull/1