### PR TITLE
Don't rebuild the GitLab docker image to set an environment variable

### DIFF
--- a/installers/aws-docker/install/NOTES.md
+++ b/installers/aws-docker/install/NOTES.md
@@ -11,10 +11,3 @@ Stop a container
 Attach a shell to a running container 
 
 `docker container exec -it <container name> bash`
-
-# Gitlab Build
-
-We use a simple Dockerfile that adds a config script to the Gitlab Docker image.
-
-The config script disables user sign up. This is not an issue if the container is not publicly exposed (to the internet). But we have it just as a precaution. See https://gitlab.com/gitlab-org/omnibus-gitlab/-/issues/2837#note_109602925
-

--- a/installers/aws-docker/install/gitlab/Dockerfile
+++ b/installers/aws-docker/install/gitlab/Dockerfile
@@ -1,6 +1,0 @@
-FROM gitlab/gitlab-ce:latest
-ARG CONFIG_DIR="/etc/gitlab"
-ENV GITLAB_POST_RECONFIGURE_SCRIPT="bash ${CONFIG_DIR}/config.sh"
-COPY config.sh ${CONFIG_DIR}/
-
-

--- a/installers/aws-docker/install/gitlab/build.sh
+++ b/installers/aws-docker/install/gitlab/build.sh
@@ -1,6 +1,0 @@
-#!/bin/bash -x
-
-pwd=`readlink -f $(dirname $0)`
-
-docker build --build-arg CONFIG_DIR=$pwd -t gitlab-ce-custom $pwd
-

--- a/installers/aws-docker/install/gitlab/config.sh
+++ b/installers/aws-docker/install/gitlab/config.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-gitlab-rails runner 'ApplicationSetting.last.update_attributes(signup_enabled: false)'
-echo "Post Reconfigure Script successfully executed"

--- a/installers/aws-docker/install/run-gitlab.sh
+++ b/installers/aws-docker/install/run-gitlab.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Note that we set GITLAB_POST_RECONFIGURE_SCRIPT to disable public
+# signup. It's currently impossible to do this via the normal config,
+# this has been an open issue for a few years.
+#
+# See https://gitlab.com/gitlab-org/omnibus-gitlab/-/issues/2837#note_109602925.
+
 pwd=`readlink -f $(dirname $0)`
 
 . $pwd/env.sh
@@ -11,22 +17,17 @@ CERT_FILE=/etc/gitlab/ssl/$HOST_DNS_NAME".crt"
 GITLAB_DATA_DIR=$CONTAINER_WORK_DIR/gitlab
 mkdir -p $GITLAB_DATA_DIR
 
-build()
-{
-	$pwd/gitlab/build.sh
-}
-
 start()
 {
-	build 
-
 	cp -r $CERT_DIR/ssl $GITLAB_DATA_DIR
 
 	docker run --name gitlab --env \
 		GITLAB_OMNIBUS_CONFIG="external_url 'https://$HOST_DNS_NAME:6443/'; gitlab_rails['lfs_enabled'] = true; nginx['listen_port'] =443 ; nginx['ssl_certificate'] = '$CERT_FILE' ; nginx['ssl_certificate_key'] = '$KEY_FILE'; letsencrypt['enable'] = false ; gitlab_rails['initial_root_password'] = '$GITLAB_ROOT_PASSWORD';" \
+		--env \
+		GITLAB_POST_RECONFIGURE_SCRIPT="gitlab-rails runner 'ApplicationSetting.last.update_attributes(signup_enabled: false)'" \
 		--publish 6443:443 \
 		-v $GITLAB_DATA_DIR:/etc/gitlab \
-		gitlab-ce-custom:latest
+		gitlab/gitlab-ce:latest
 }
 
 stop()


### PR DESCRIPTION
Before this patch we used a workaround taken directly from
https://gitlab.com/gitlab-org/omnibus-gitlab/-/issues/2837#note_109602925,
however the workaround is far more involved than it needs to be.

Instead of setting `ENV` in a Dockerfile, we can simply set an
environment variable on the CLI with the same effect, saving users the
time it takes to build a docker image, as well as the maintenance
overhead of running a custom build script for updates.


----

Sorry for the direct patch here; but it's a tiny thing so I don't
think it needs to go through issues :)

If you think the doc is still needed to point out public signup is
disabled, please do tell.