### PR TITLE
Update studio config to prepare for metadata server

### DIFF
--- a/installers/aws-docker/install/templates/studio/uiConfig.json
+++ b/installers/aws-docker/install/templates/studio/uiConfig.json
@@ -4,6 +4,9 @@
   "sdlc": {
     "url": "__LEGEND_SDLC_URL__/api"
   },
+  "metadata": {
+    "url": "__LEGEND_DEPOT_URL__/api"
+  },
   "engine": {
     "url": "__LEGEND_ENGINE_URL__/api"
   },

--- a/installers/aws-docker/install/templates/studio/uiConfig.json
+++ b/installers/aws-docker/install/templates/studio/uiConfig.json
@@ -16,7 +16,6 @@
   "options": {
     "core": {
       "TEMPORARY__disableSDLCProjectStructureSupport": true,
-      "TEMPORARY__disableNonModelStoreSupports": true,
       "TEMPORARY__disableServiceRegistration": true
     }
   }

--- a/installers/docker-compose/shared/templates/studio/uiConfig.json
+++ b/installers/docker-compose/shared/templates/studio/uiConfig.json
@@ -4,6 +4,9 @@
   "sdlc": {
     "url": "__LEGEND_SDLC_URL__/api"
   },
+  "metadata": {
+    "url": "__LEGEND_DEPOT_URL__/api"
+  },
   "engine": {
     "url": "__LEGEND_ENGINE_URL__/api"
   },

--- a/installers/docker-compose/shared/templates/studio/uiConfig.json
+++ b/installers/docker-compose/shared/templates/studio/uiConfig.json
@@ -16,7 +16,6 @@
   "options": {
     "core": {
       "TEMPORARY__disableSDLCProjectStructureSupport": true,
-      "TEMPORARY__disableNonModelStoreSupports": true,
       "TEMPORARY__disableServiceRegistration": true
     }
   }


### PR DESCRIPTION
This is to accommodate for the latest version of Studio [finos/legend-studio:0.2.27](https://hub.docker.com/layers/finos/legend-studio/0.2.27/images/sha256-f971b089918b9314fd0e5d7c070d2236864e359448e66261f1d65e51bd051a8d?context=explore) whose config now expects `metadata` field to be filled