### PR TITLE
Minor improvement to release page and create new release 2021-06-09

### DIFF
--- a/releases/2021-02-03/manifest.json
+++ b/releases/2021-02-03/manifest.json
@@ -1,5 +1,6 @@
 {
   "version": "2021-02-03",
+  "timestamp": 1612353600000,
   "core": {
     "finos/legend-studio": "0.1.0",
     "finos/legend-engine-server": "2.10.0",

--- a/releases/2021-02-08/manifest.json
+++ b/releases/2021-02-08/manifest.json
@@ -1,5 +1,6 @@
 {
   "version": "2021-02-08",
+  "timestamp": 1612785600000,
   "core": {
     "finos/legend-studio": "0.1.1",
     "finos/legend-engine-server": "2.10.1",

--- a/releases/2021-02-09/manifest.json
+++ b/releases/2021-02-09/manifest.json
@@ -1,5 +1,6 @@
 {
   "version": "2021-02-09",
+  "timestamp": 1612872000000,
   "core": {
     "finos/legend-studio": "0.1.1",
     "finos/legend-engine-server": "2.11.0",

--- a/releases/2021-02-12/manifest.json
+++ b/releases/2021-02-12/manifest.json
@@ -1,5 +1,6 @@
 {
   "version": "2021-02-12",
+  "timestamp": 1613131200000,
   "core": {
     "finos/legend-studio": "0.1.1",
     "finos/legend-engine-server": "2.12.0",

--- a/releases/2021-02-17/manifest.json
+++ b/releases/2021-02-17/manifest.json
@@ -1,5 +1,6 @@
 {
   "version": "2021-02-17",
+  "timestamp": 1613563200000,
   "core": {
     "finos/legend-studio": "0.1.1",
     "finos/legend-engine-server": "2.13.0",

--- a/releases/2021-02-18/manifest.json
+++ b/releases/2021-02-18/manifest.json
@@ -1,5 +1,6 @@
 {
   "version": "2021-02-18",
+  "timestamp": 1613649600000,
   "core": {
     "finos/legend-studio": "0.1.1",
     "finos/legend-engine-server": "2.14.0",

--- a/releases/2021-03-03/manifest.json
+++ b/releases/2021-03-03/manifest.json
@@ -1,5 +1,6 @@
 {
   "version": "2021-03-03",
+  "timestamp": 1614772800000,
   "core": {
     "finos/legend-studio": "0.1.1",
     "finos/legend-engine-server": "2.16.0",

--- a/releases/2021-03-09/manifest.json
+++ b/releases/2021-03-09/manifest.json
@@ -1,5 +1,6 @@
 {
   "version": "2021-03-09",
+  "timestamp": 1615291200000,
   "core": {
     "finos/legend-studio": "0.1.1",
     "finos/legend-engine-server": "2.17.0",

--- a/releases/2021-03-12/manifest.json
+++ b/releases/2021-03-12/manifest.json
@@ -1,5 +1,6 @@
 {
   "version": "2021-03-12",
+  "timestamp": 1615550400000,
   "core": {
     "finos/legend-studio": "0.1.1",
     "finos/legend-engine-server": "2.18.0",

--- a/releases/2021-03-15/manifest.json
+++ b/releases/2021-03-15/manifest.json
@@ -1,5 +1,6 @@
 {
   "version": "2021-03-15",
+  "timestamp": 1615809600000,
   "core": {
     "finos/legend-studio": "0.1.1",
     "finos/legend-engine-server": "2.18.0",

--- a/releases/2021-03-16/manifest.json
+++ b/releases/2021-03-16/manifest.json
@@ -1,5 +1,6 @@
 {
   "version": "2021-03-16",
+  "timestamp": 1615896000000,
   "core": {
     "finos/legend-studio": "0.1.1",
     "finos/legend-engine-server": "2.18.0",

--- a/releases/2021-03-18/manifest.json
+++ b/releases/2021-03-18/manifest.json
@@ -1,5 +1,6 @@
 {
   "version": "2021-03-18",
+  "timestamp": 1616068800000,
   "core": {
     "finos/legend-studio": "0.1.1",
     "finos/legend-engine-server": "2.20.0",

--- a/releases/2021-03-22/manifest.json
+++ b/releases/2021-03-22/manifest.json
@@ -1,5 +1,6 @@
 {
   "version": "2021-03-22",
+  "timestamp": 1616414400000,
   "core": {
     "finos/legend-studio": "0.2.11",
     "finos/legend-engine-server": "2.20.0",

--- a/releases/2021-03-24/manifest.json
+++ b/releases/2021-03-24/manifest.json
@@ -1,5 +1,6 @@
 {
   "version": "2021-03-24",
+  "timestamp": 1616587200000,
   "core": {
     "finos/legend-studio": "0.2.15",
     "finos/legend-engine-server": "2.20.0",

--- a/releases/2021-03-26/manifest.json
+++ b/releases/2021-03-26/manifest.json
@@ -1,5 +1,6 @@
 {
   "version": "2021-03-26",
+  "timestamp": 1616760000000,
   "core": {
     "finos/legend-studio": "0.2.16",
     "finos/legend-engine-server": "2.20.0",

--- a/releases/2021-03-31/manifest.json
+++ b/releases/2021-03-31/manifest.json
@@ -1,5 +1,6 @@
 {
   "version": "2021-03-31",
+  "timestamp": 1617192000000,
   "core": {
     "finos/legend-studio": "0.2.16",
     "finos/legend-engine-server": "2.21.0",

--- a/releases/2021-06-09/manifest.json
+++ b/releases/2021-06-09/manifest.json
@@ -1,0 +1,11 @@
+{
+  "version": "2021-06-09",
+  "timestamp": 1623268599213,
+  "core": {
+    "finos/legend-studio": "0.2.38",
+    "finos/legend-engine-server": "2.32.0",
+    "finos/legend-sdlc-server": "0.36.0",
+    "gitlab/gitlab-ce": "13.9.3-ce.0",
+    "mongo": "4.0"
+  }
+}

--- a/website/pages/en/releases.js
+++ b/website/pages/en/releases.js
@@ -19,10 +19,7 @@ function Releases(props) {
       if (!fs.lstatSync(fullDir).isDirectory()) {
         return undefined;
       }
-      return {
-        version: dir,
-        manifest: require(`${fullDir}/manifest.json`),
-      };
+      return require(`${fullDir}/manifest.json`);
     })
     .filter(Boolean);
   return (
@@ -66,23 +63,25 @@ function Releases(props) {
               </tr>
             </thead>
             <tbody>
-              {releases.map((release) => (
-                <tr key={release.version}>
-                  <td>{release.version}</td>
-                  <td>
-                    finos/legend-studio:
-                    {release.manifest.core["finos/legend-studio"]}
-                  </td>
-                  <td>
-                    finos/legend-engine-server:
-                    {release.manifest.core["finos/legend-engine-server"]}
-                  </td>
-                  <td>
-                    finos/legend-sdlc-server:
-                    {release.manifest.core["finos/legend-engine-server"]}
-                  </td>
-                </tr>
-              ))}
+              {releases
+                .sort((a, b) => b.timestamp - a.timestamp)
+                .map((release) => (
+                  <tr key={release.version}>
+                    <td>{release.version}</td>
+                    <td>
+                      finos/legend-studio:
+                      {release.core["finos/legend-studio"]}
+                    </td>
+                    <td>
+                      finos/legend-engine-server:
+                      {release.core["finos/legend-engine-server"]}
+                    </td>
+                    <td>
+                      finos/legend-sdlc-server:
+                      {release.core["finos/legend-sdlc-server"]}
+                    </td>
+                  </tr>
+                ))}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
We add `timestamp` field to manifest. This will help with future releases that might not follow the current convention (e.g. `2021-02-02-hotfix, 2021-02-02.2` etc.). Also, we can use this timestamp field to sort the release (latest first).