### PR TITLE
fix copy commands in setup

### DIFF
--- a/installers/docker-compose/legend-with-remote-gitlab/scripts/setup.sh
+++ b/installers/docker-compose/legend-with-remote-gitlab/scripts/setup.sh
@@ -95,5 +95,5 @@ echo "$LEGEND_STUDIO_PUBLIC_URL/studio/log.in/callback"
 ##########################################
 
 cp -r $PWD $BUILD_DIR/scripts
-cp -r $PWD/../../shared/scripts/ $BUILD_DIR/scripts
-cp -r $PWD/../../shared/templates $BUILD_DIR/templates
+cp -r $PWD/../../shared/scripts $BUILD_DIR
+cp -r $PWD/../../shared/templates $BUILD_DIR


### PR DESCRIPTION
`cp -r` command will create a new directory if the destination
directory does not exist, but create sub-directory under it if
it exists. This results a nested scripts/scripts folder to be
created which is not intended. This causes problem for docker
volume binding.

remove the tailing folder names to get rid of this issue.

Signed-off-by: Kejia Hu <kejia.hu@codethink.co.uk>