### PR TITLE
Fix Docker-compose installers '/scripts' volume structure.

### DIFF
--- a/installers/docker-compose/legend-studio-dev/scripts/setup.sh
+++ b/installers/docker-compose/legend-studio-dev/scripts/setup.sh
@@ -88,5 +88,5 @@ echo "http://localhost:$LEGEND_STUDIO_PORT/studio/log.in/callback"
 ##########################################
 
 cp -r $PWD $BUILD_DIR/scripts
-cp -r $PWD/../../shared/scripts/ $BUILD_DIR/scripts
+cp -r $PWD/../../shared/scripts/* $BUILD_DIR/scripts
 cp -r $PWD/../../shared/templates $BUILD_DIR/templates

--- a/installers/docker-compose/legend-with-remote-gitlab/scripts/setup.sh
+++ b/installers/docker-compose/legend-with-remote-gitlab/scripts/setup.sh
@@ -95,5 +95,5 @@ echo "$LEGEND_STUDIO_PUBLIC_URL/studio/log.in/callback"
 ##########################################
 
 cp -r $PWD $BUILD_DIR/scripts
-cp -r $PWD/../../shared/scripts/ $BUILD_DIR/scripts
+cp -r $PWD/../../shared/scripts/* $BUILD_DIR/scripts
 cp -r $PWD/../../shared/templates $BUILD_DIR/templates

--- a/installers/docker-compose/legend/scripts/setup.sh
+++ b/installers/docker-compose/legend/scripts/setup.sh
@@ -149,5 +149,5 @@ echo "access token: $GITLAB_PRIVATE_ACCESS_TOKEN"
 ##########################################
 
 cp -r $PWD $BUILD_DIR/scripts
-cp -r $PWD/../../shared/scripts/ $BUILD_DIR/scripts
+cp -r $PWD/../../shared/scripts/* $BUILD_DIR/scripts
 cp -r $PWD/../../shared/templates $BUILD_DIR/templates


### PR DESCRIPTION
The Docker-compose-based installers overwrite the COMMANDs in the
container images of the Engine and SDLC components with some scripts
which handle some setup tasks before starting the actual services.

Part of the setup stepts these scripts do is attempting to run a
`gen-config.sh` script they assume is located in `/scripts`, but the
various pre-Docker-compose scripts accidentally copy `gen-config.sh`
into a subdirectory also called '/scripts'. (thus, inside the containers,
the actual path would be '/scripts/scripts/gen-config.sh')

This patch ensures that all of the scripts required by the Engine and
SDLC containers are located under the single '/scripts' directory as
was originally intended.