### PR TITLE
Adds Juju release publish github action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,77 @@
+name: Publish Legend Charms
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs everyday at 00:00. (see https://crontab.guru)
+    - cron: '0 0 * * *'
+
+jobs:
+  publish-images:
+    name: Publish Legend Charms
+    runs-on: ubuntu-20.04
+    env:
+      CHARMCRAFT_AUTH: "${{ secrets.CHARMCRAFT_AUTH }}"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install Docker
+        uses: docker-practice/actions-setup-docker@master
+
+      - name: Install Dependencies
+        run: |
+          sudo snap install jq
+          sudo snap install charmcraft --classic
+
+      - name: Upload Docker images to Charmhub
+        run: |
+          set -x
+
+          release_charm_with_image(){
+            charm_name="$1"
+            charm_resource="$2"
+            img_name="$3"
+            release_version="$4"
+
+            release_file="releases/${release_version}/manifest.json"
+
+            # Getting the release version.
+            img_version=$(cat "${release_file}" | jq --raw-output ".core.\"${img_name}\"")
+
+            # Pulling the image.
+            image="${img_name}:${img_version}"
+            docker pull "${image}"
+
+            # Get the image SHA.
+            image_sha=$(docker inspect --format '{{ .Id }}' ${image})
+
+            # Upload image to Charmhub. CHARMCRAFT_AUTH should be loaded in the environment, and
+            # it should have sufficient permissions to push the resource.
+            charmcraft upload-resource --quiet "${charm_name}" "${charm_resource}" --image=${image_sha}
+
+            # Get the last revision number and image revision number and release.
+            charm_rev=$(charmcraft revisions ${charm_name} | awk 'FNR == 2 {print $1}')
+            img_rev=$(charmcraft resource-revisions "${charm_name}" "${charm_resource}" | awk 'FNR == 2 {print $1}')
+            charmcraft release "${charm_name}" --revision=${charm_rev} --channel="${release_version}/edge" --resource="${charm_resource}:${img_rev}"
+
+            # Also release it as the latest.
+            charmcraft release "${charm_name}" --revision=${charm_rev} --channel=edge --resource="${charm_resource}:${img_rev}"
+          }
+
+          # Treat releases newer than 2022.04.01.
+          for release in $(ls releases/ | gawk '{ if ($1 > "2022-04-01") { print } }')
+          do
+            echo "Treating ${release}..."
+            # If the current release was already published, skip.
+            if charmcraft status finos-legend-engine-k8s | grep $release
+            then
+              continue
+            fi
+
+            release_charm_with_image finos-legend-studio-k8s studio-image finos/legend-studio "${release}"
+            release_charm_with_image finos-legend-engine-k8s engine-image finos/legend-engine-server "${release}"
+            release_charm_with_image finos-legend-sdlc-k8s sdlc-image finos/legend-sdlc-server "${release}"
+          done

--- a/releases/2022-04-04/manifest.json
+++ b/releases/2022-04-04/manifest.json
@@ -1,0 +1,12 @@
+{
+  "version": "2022-04-04",
+  "timestamp": 1634599077493,
+  "releaseNotesUrl": "https://legend.finos.org/docs/release/release-2022-04-04",
+  "core": {
+    "finos/legend-studio": "3.4.0",
+    "finos/legend-engine-server": "2.55.0",
+    "finos/legend-sdlc-server": "0.69.1",
+    "gitlab/gitlab-ce": "13.9.3-ce.0",
+    "mongo": "4.0"
+  }
+}


### PR DESCRIPTION
This action will be triggered whenever a change is detected in the releases/ folder.

If there is a new release that was not yet published on charmhub, it will upload the respective FINOS Legend Engine, SDLC, and Studio images into charmhub and make a release. It will also create a new release on latest.