### PR TITLE
Add back legacy Studio documentation till we migrate

### DIFF
--- a/website/static/resource/studio/documentation.json
+++ b/website/static/resource/studio/documentation.json
@@ -1,0 +1,328 @@
+{
+  "entries": {
+    "grammar.parser.pure": {
+      "markdownText": {
+        "value": "Core `Pure` (coressponding to `###Pure` section in `Pure`) concerns with fundamental modelling concepts, such as, classes (data models), enumerations, associations, functions, etc."
+      },
+      "title": "What is core Pure about?",
+      "url": "https://legend.finos.org/docs/reference/legend-language"
+    },
+    "dsl-mapping.grammar.parser": {
+      "markdownText": {
+        "value": "`Mapping DSL` (coressponding to `###Mapping` section in `Pure`) concerns with data transformation specifications: this includes model-to-model transformation, store specification to model transformation, etc."
+      },
+      "title": "What is Mapping DSL about?"
+    },
+    "dsl-connection.grammar.parser": {
+      "markdownText": {
+        "value": "`Connection DSL` (coressponding to `###Connection` section in `Pure`) concerns with data stores access"
+      },
+      "title": "What is Connection DSL about?"
+    },
+    "dsl-runtime.grammar.parser": {
+      "markdownText": {
+        "value": "`Runtime DSL` (coressponding to `###Runtime` section in `Pure`) concerns with the organization/grouping and contextual usage of connections"
+      },
+      "title": "What is Runtime DSL about?"
+    },
+    "es-relational.grammar.parser": {
+      "markdownText": {
+        "value": "`External Store Relational DSL` (coressponding to `###Relational` section in `Pure`) concerns with mappings, connections, and specifications for relational databases"
+      },
+      "title": "What is External Store Relational DSL about?"
+    },
+    "dsl-service.grammar.parser": {
+      "markdownText": {
+        "value": "`Service DSL` (coressponding to `###Service` section in `Pure`) concerns with generation and deployment of Pure query to productionize data extraction and exploration"
+      },
+      "title": "What is Service DSL about?"
+    },
+    "dsl-external-format.grammar.parser": {
+      "title": "What is External Format DSL about?",
+      "markdownText": {
+        "value": "`External Format DSL` (coressponding to `###ExternalFormat` section in `Pure`) concerns with the serialization between data models and external formats like CSV, JSON, etc."
+      }
+    },
+    "dsl-generation-specification.grammar.parser": {
+      "markdownText": {
+        "value": "`Generation Specification DSL` (coressponding to `###GenerationSpecification` section in `Pure`) concerns with organization of generation pipeline"
+      },
+      "title": "What is Generation Specification DSL about?"
+    },
+    "dsl-file-generation.grammar.parser": {
+      "markdownText": {
+        "value": "`File Generation DSL` (coressponding to `###FileGeneration` section in `Pure`) concerns with generating models in external formats (e.g. Avro, Protobuf, JSON Schema, etc.)"
+      },
+      "title": "What is File Generation DSL about?"
+    },
+    "dsl-data.grammar.parser": {
+      "markdownText": {
+        "value": "`Data DSL` (coressponding to `###Data` section in `Pure`) concerns with storing data which can be various purpose including testing"
+      },
+      "title": "What is Data DSL about?"
+    },
+    "grammar.class": {
+      "markdownText": {
+        "value": "A `Class` specifies a data model's structure, inheritance, and constraints"
+      },
+      "title": "What is a class element?"
+    },
+    "grammar.profile": {
+      "markdownText": {
+        "value": "A `Profile` provides a generic extension mechanism for customizing existing data models; some of its uses include documentating and classifying data models"
+      },
+      "title": "What is a profile element?"
+    },
+    "grammar.enumeration": {
+      "markdownText": {
+        "value": "An `Enumeration` specifies the complete list of value that a given type may acquire"
+      },
+      "title": "What is an enumeration element?"
+    },
+    "grammar.measure": {
+      "markdownText": {
+        "value": "A `Measure` (fairly similar to `Enumeration`) specifies a measurble type: it specifies units (as well as conversion functions to convert values between them)"
+      },
+      "title": "What is a measure element?"
+    },
+    "grammar.association": {
+      "markdownText": {
+        "value": "An `Association` specifies a linking between between 2 data models"
+      },
+      "title": "What is an association element?"
+    },
+    "grammar.function": {
+      "markdownText": {
+        "value": "A `Function` specifies a piece of reusable Pure code logic"
+      },
+      "title": "What is a function element?"
+    },
+    "dsl-mapping.grammar.element.mapping": {
+      "markdownText": {
+        "value": "A `Mapping` specifies a transformation between models, including model-to-model, store-to-model, enumeration-to-model, etc."
+      },
+      "title": "What is a mapping element?"
+    },
+    "es-relational.grammar.element.database": {
+      "markdownText": {
+        "value": "A `Database` specifies the structure (schema, table, view) and joins of a relational database"
+      },
+      "title": "What is a database element?"
+    },
+    "dsl-service.grammar.element.service": {
+      "markdownText": {
+        "value": "A `Service` specifies query execution and deployment information so the it can be productionized: e.g. exposing it via API endpoints"
+      },
+      "title": "What is a service element?"
+    },
+    "dsl-mapping.grammar.element.runtime": {
+      "markdownText": {
+        "value": "A `Runtime` specifies a logical grouping of connections which can be used for query execution"
+      },
+      "title": "What is a runtime element?"
+    },
+    "dsl-mapping.grammar.element.connection": {
+      "markdownText": {
+        "value": "A `Connection` specifies access to data store(s) including data store specifications and authentication strategies"
+      },
+      "title": "What is a connection element?"
+    },
+    "dsl-external-format.grammar.element.binding": {
+      "title": "What is a binding element?",
+      "markdownText": {
+        "value": "A `Binding` element specifies the association between a set of models and their corresponding schemas in external formats (e.g. JSON, CSV, etc.) to ensure the models and schemas always kept in-sync"
+      }
+    },
+    "dsl-external-format.grammar.element.schema-set": {
+      "title": "What is a schema-set element?",
+      "markdownText": {
+        "value": "A `Schema-set` element specifies schemas in external formats (e.g. JSON, CSV, etc.), from which Pure models can be generated"
+      }
+    },
+    "dsl-generation-specification.grammar.element.generation-specification": {
+      "markdownText": {
+        "value": "A `Generation Specification` provides the pipeline for all generations"
+      },
+      "title": "What is a generation specification element?"
+    },
+    "dsl-file-generation.grammar.element.file-generation-specification": {
+      "markdownText": {
+        "value": "A `File Generation Specification` specifies the generation of external format from Pure models"
+      },
+      "title": "What is a file generation specification element?"
+    },
+    "dsl-data.grammar.element.data": {
+      "markdownText": {
+        "value": "A `Data` element stores data which can be used for various purposes, including testing"
+      },
+      "title": "What is a data element?"
+    },
+    "dsl-mapping.grammar.connection.json-model-connection": {
+      "markdownText": {
+        "value": "A JSON model connection specifies access to a model store where the retrieved data will be in JSON format"
+      },
+      "title": "What is a JSON model connection?"
+    },
+    "dsl-mapping.grammar.connection.xml-model-connection": {
+      "markdownText": {
+        "value": "A XML model connection specifies access to a model store where the retrieved data will be in XML format"
+      },
+      "title": "What is a XML model connection?"
+    },
+    "dsl-mapping.grammar.connection.model-chain-connection": {
+      "markdownText": {
+        "value": "A model chain connection provides a mechanism to sequence mappings (data transformations) and simulate a data store"
+      },
+      "title": "What is a model chain connection?"
+    },
+    "es-relational.grammar.connection.relational-database-connection": {
+      "markdownText": {
+        "value": "A relational data connection specifies access to a relational database, including the store specification and authentication strategy"
+      },
+      "title": "What is a relational database connection?"
+    },
+    "question.what-is-dsl": {
+      "markdownText": {
+        "value": "A `domain-specific language` (DSL) is a higher-level abstraction optimized for a specific domain/class of problems. Each `DSL` often has their own `Pure` sub-grammar, which partition `Pure` code into sections (each starts with a header, such as `###Pure`, `###Mapping`, etc."
+      },
+      "title": "What is a domain-specific language (DSL)?"
+    },
+    "question.what-is-basic-pure-language": {
+      "title": "What are the basics of Pure language?",
+      "url": "https://legend.finos.org/docs/reference/legend-language"
+    },
+    "question.how-to-write-pure-lambda": {
+      "title": "How do I write a lambda function in Pure?",
+      "url": "https://legend.finos.org/docs/reference/legend-language#lambda"
+    },
+    "question.how-to-define-a-class": {
+      "title": "How do I define a class?",
+      "url": "https://legend.finos.org/docs/tutorials/studio-tutorial#define-a-new-class"
+    },
+    "question.how-to-define-a-class-property": {
+      "title": "How do I define a class property?",
+      "url": "https://legend.finos.org/docs/tutorials/studio-tutorial#add-a-property-primitive-data-type"
+    },
+    "question.how-to-define-a-class-derivation": {
+      "title": "How do I define a class derivation (derived property)?",
+      "url": "https://legend.finos.org/docs/tutorials/studio-tutorial#add-a-derived-property"
+    },
+    "question.how-to-write-a-class-derivation-lambda": {
+      "related": [
+        "question.how-to-write-pure-lambda",
+        "question.what-is-basic-pure-language"
+      ],
+      "title": "How to write a derived property lambda in Pure?",
+      "url": "https://legend.finos.org/docs/reference/legend-language#derivation"
+    },
+    "question.how-to-define-a-class-constraint": {
+      "title": "How do I put constraint on a class?",
+      "url": "https://legend.finos.org/docs/tutorials/studio-tutorial#add-a-constraint"
+    },
+    "question.how-to-write-a-class-constraint-lambda": {
+      "related": [
+        "question.how-to-write-pure-lambda",
+        "question.what-is-basic-pure-language"
+      ],
+      "title": "How to write a constraint lambda in Pure?",
+      "url": "https://legend.finos.org/docs/reference/legend-language#constraint"
+    },
+    "question.how-to-specify-a-class-supertype": {
+      "title": "How do I specify a supertype of a class?",
+      "url": "https://legend.finos.org/docs/tutorials/studio-tutorial#add-a-super-type"
+    },
+    "question.how-to-write-a-service-test": {
+      "title": "How do I specify a service test?",
+      "url": "https://legend.finos.org/docs/tutorials/studio-tutorial#create-a-service-test"
+    },
+    "question.how-to-write-a-service-test-with-parameters": {
+      "title": "How do I specify a service test with parameters?",
+      "related": ["question.how-to-write-a-service-test"],
+      "url": "https://legend.finos.org/docs/tutorials/studio-tutorial#with-parameters"
+    },
+    "question.how-to-write-a-service-test-with-data-element": {
+      "title": "How do I use data element in service test?",
+      "related": ["question.how-to-write-a-service-test"],
+      "url": "https://legend.finos.org/docs/tutorials/studio-tutorial#with-data-element"
+    },
+    "question.how-to-write-a-service-multi-execution": {
+      "title": "How do I specify a service with multi executions?",
+      "url": "https://legend.finos.org/docs/tutorials/studio-tutorial#create-a-multi-execution-service"
+    },
+    "context.class-editor": {
+      "related": [
+        "question.how-to-define-a-class",
+        "question.how-to-define-a-class-property",
+        "question.how-to-define-a-class-derivation",
+        "question.how-to-define-a-class-constraint",
+        "question.how-to-specify-a-class-supertype"
+      ]
+    },
+    "dsl-text.grammar.parser": {
+      "markdownText": {
+        "value": "`Text DSL` (corresponding to header `###DataSpace` section in `Pure`) concerns with storing data in plain-text"
+      },
+      "title": "What is Text DSL about?"
+    },
+    "dsl-text.grammar.element.text": {
+      "markdownText": {
+        "value": "A `Text` element stores plain-text content with a specified content-type, which can be used for formatting, syntax-highlighting"
+      },
+      "title": "What is a text element?"
+    },
+    "dsl-diagram.grammar.parser": {
+      "markdownText": {
+        "value": "`Diagram DSL`  (corresponding to `###Diagram` section in `Pure`) concerns with visualizing data models and their relationship"
+      },
+      "title": "What is Diagram DSL about?"
+    },
+    "dsl-diagram.grammar.element.diagram": {
+      "markdownText": {
+        "value": "A `Diagram` element specifies the visualization/rendering of data models and their relationship"
+      },
+      "title": "What is a diagram element?"
+    },
+    "dsl-dataspace.grammar.parser": {
+      "markdownText": {
+        "value": "`DataSpace DSL` (corresponding to header `###DataSpace` section in `Pure`) concerns with providing information and documentation about the taxonomy of data models"
+      },
+      "title": "What is DataSpace DSL about?"
+    },
+    "dsl-dataspace.grammar.element.data-space": {
+      "markdownText": {
+        "value": "A `Data-space` element specifies a grouping of model diagrams, execution context (mapping, runtime), test data, and so on to help communicate about the _meaning_, _usage_, and relationships of data models and to help users quickly explore and understand the models"
+      },
+      "title": "What is a data-space element?"
+    },
+    "dsl-persistence.grammar.parser": {
+      "markdownText": {
+        "value": "`Persistence DSL` (corresponding to `###Persistence` section in `Pure`) provides specifications for persisting the result of a service invocation into a target data store"
+      },
+      "title": "What is Persistence DSL about?"
+    },
+    "dsl-persistence.grammar.element.persistence": {
+      "markdownText": {
+        "value": "A `Persistence` element consists of a trigger to initiate persistence, a service to source and transform data, and a persister describing how to write to the target (e.g. ingest mode [snapshot | delta | append-only], temporality [non-temporal | unitemporal | bitemporal], and transactional semantics)"
+      },
+      "title": "What is a persistence element?"
+    },
+    "dsl-persistence.grammar.element.persistence-context": {
+      "markdownText": {
+        "value": "A `PersistenceContext` element refers to a `Persistence` element, defines the runtime platform for persistence (e.g. AWS Glue), and may include additional runtime platform and environment details necessary for execution (e.g. data source connections, authentication strategies, and service input parameters)"
+      },
+      "title": "What is a persistence context element?"
+    },
+    "es-service.grammar.parser": {
+      "markdownText": {
+        "value": "`External Store Service DSL` (corresponding to `###ServiceStore` section in `Pure`) concerns with data store specifications which enable accessing data from API endpoints"
+      },
+      "title": "What is External Store Service DSL about?"
+    },
+    "es-service.grammar.element.service-store": {
+      "markdownText": {
+        "value": "A service store element specifies API endpoints as data source"
+      },
+      "title": "What is a service store element?"
+    }
+  }
+}


### PR DESCRIPTION
This partially reverts https://github.com/finos/legend/pull/538
We can remove this file when we completely migrate over