### PR TITLE
Documentation homepage fix 

### DIFF
--- a/v2-website/static/indexBackup.html
+++ b/v2-website/static/indexBackup.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
   <head>
     <meta charset="UTF-8" />
-    <!-- Prevent size of site and element to stuck at 980px (since iOS, by default assumes the width of 980px).
+    <!-- Preventing size of site and element to stuck at 980px (since iOS, by default assumes the width of 980px).
       However, to avoid the page starts zoomed in in portrait mode, we must not set the `initial-scale=1`
       See https://stackoverflow.com/questions/35425506/sites-body-and-elements-are-stuck-on-980px-width-wont-scale-down
       See https://stackoverflow.com/a/14734142


### PR DESCRIPTION
Removing `index.html` file to fix homepage different rendering. 