### PR TITLE
Configure GA4

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -43,8 +43,9 @@ module.exports = {
         theme: {
           customCss: "./src/css/customTheme.css",
         },
-        googleAnalytics: {
-          trackingID: "UA-89349362-7",
+        gtag: {
+          trackingID: 'G-B6ZG606WLL',
+          anonymizeIP: true,
         },
       },
     ],

--- a/website/package.json
+++ b/website/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@docsearch/js": "3",
     "@docusaurus/core": "^2.2.0",
+    "@docusaurus/plugin-google-gtag": "^2.4.1",
     "@docusaurus/preset-classic": "^2.2.0",
     "@docusaurus/theme-search-algolia": "^2.2.0",
     "classnames": "^2.3.2",


### PR DESCRIPTION
This PR uses the [Docusaurus gtag plugin](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag) to update the website to the latest version of Google Analytics (GA4). 