### PR TITLE
Update start.gitlab-pat.sh to mount docker.sock for nested container

### DIFF
--- a/installers/omnibus/scripts/start.gitlab-pat.sh
+++ b/installers/omnibus/scripts/start.gitlab-pat.sh
@@ -49,7 +49,7 @@ if [[ "$LEGEND_OMNIBUS_CONFIG_EXPOSE_BACKEND_PORTS" = true ]]; then
     --env LEGEND_OMNIBUS_CONFIG_GITLAB_PAT="$LEGEND_OMNIBUS_CONFIG_GITLAB_PAT" \
     $IMAGE)
 else
-  CONTAINER_ID=$(docker run --platform=linux/amd64 -d \
+  CONTAINER_ID=$(docker run -v /var/run/docker.sock:/var/run/docker.sock --platform=linux/amd64 -d \
     --pull="$PULL_STRATEGY" docker run \
     -p 6900:6900 \
     --env LEGEND_OMNIBUS_CONFIG_SDLC_MODE="gitlab-pat" \


### PR DESCRIPTION
Without this, the error below was being hit on my Ubuntu VM box 
```
docker: error during connect: Post "http://docker:2375/v1.24/containers/create": dial tcp: lookup docker on 192.168.1.1:53: no such host.
```

OS version info:
```
root@workvm-july:/home/user# uname -a
Linux workvm-july 5.19.0-46-generic #47~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Jun 21 15:35:31 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
```

Related information page: https://releasecandidate.dev/posts/2021/how-to-fix-docker-no-such-host-port-53/
