### PR TITLE
Run only changed showcases on PR

### DIFF
--- a/.github/workflows/check-showcases.yml
+++ b/.github/workflows/check-showcases.yml
@@ -43,6 +43,10 @@ jobs:
           java-version: "11"
           distribution: "temurin"
           cache: "maven"
+      - name: Get Changed Files
+        id: changed_files
+        working-directory: ./showcases
+        run: echo "CHANGED_FILES=`git diff --name-only | paste -sd ','`" >> "$GITHUB_OUTPUT"
       - name: Run test
         working-directory: ./showcases
         run: |
@@ -50,4 +54,4 @@ jobs:
           mvn -B -Dmaven.surefire.thread.count=$THREAD_COUNT -Dshowcase.locations=$SHOWCASE_LOCATIONS test
         env:
           THREAD_COUNT: 3
-          SHOWCASE_LOCATIONS: data
+          SHOWCASE_LOCATIONS: ${{ steps.changed_files.outputs.CHANGED_FILES }}

--- a/.github/workflows/check-showcases.yml
+++ b/.github/workflows/check-showcases.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Get Changed Files for PR
         if: ${{ github.event_name == 'pull_request' }}
         working-directory: ./showcases
-        run: echo "CHANGED_FILES=`git diff --name-only | paste -sd ','`" >> "$GITHUB_ENV"
+        run: echo "CHANGED_FILES=`git diff --name-only $GITHUB_BASE_REF...$GITHUB_HEAD_REF | paste -sd ','`" >> "$GITHUB_ENV"
       - name: Run test
         working-directory: ./showcases
         run: |

--- a/.github/workflows/check-showcases.yml
+++ b/.github/workflows/check-showcases.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "showcases/**"
   pull_request:
+    types: [opened, reopened, synchronize, edited]
     branches:
       - "**"
     paths:
@@ -43,15 +44,21 @@ jobs:
           java-version: "11"
           distribution: "temurin"
           cache: "maven"
-      - name: Get Changed Files
-        id: changed_files
+      # For PRs only want to run changed files
+      - name: Get Changed Files for PR
+        if: ${{ github.event_name == 'pull_request' }}
         working-directory: ./showcases
-        run: echo "CHANGED_FILES=`git diff --name-only | paste -sd ','`" >> "$GITHUB_OUTPUT"
+        run: echo "CHANGED_FILES=`git diff --name-only | paste -sd ','`" >> "$GITHUB_ENV"
       - name: Run test
         working-directory: ./showcases
         run: |
+          if [ $SHOWCASE_LOCATIONS == "" ]; then
+            locations=data
+          else
+            locations=$SHOWCASE_LOCATIONS
+          fi
           mvn versions:use-latest-versions
-          mvn -B -Dmaven.surefire.thread.count=$THREAD_COUNT -Dshowcase.locations=$SHOWCASE_LOCATIONS test
+          mvn -B -Dmaven.surefire.thread.count=$THREAD_COUNT -Dshowcase.locations=$locations test
         env:
           THREAD_COUNT: 3
-          SHOWCASE_LOCATIONS: ${{ steps.changed_files.outputs.CHANGED_FILES }}
+          SHOWCASE_LOCATIONS: ${{ env.CHANGED_FILES }}


### PR DESCRIPTION
Restricts types of pull request events that can trigger this action.

Runs tests only for changed paths detected by git.