### PR TITLE
Update legend.engine.version to 4.73.0

### DIFF
--- a/showcases/pom.xml
+++ b/showcases/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.surefire.thread.count>3</maven.surefire.thread.count>
         <showcase.projects.location>data</showcase.projects.location>
-        <legend.engine.version>4.68.0</legend.engine.version>
+        <legend.engine.version>4.73.0</legend.engine.version>
 
     </properties>
 

--- a/website/pct-generation/pom.xml
+++ b/website/pct-generation/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <platform.legend-engine.version>3.21.1</platform.legend-engine.version>
-        <legend.engine.version>4.52.0</legend.engine.version>
+        <legend.engine.version>4.73.0</legend.engine.version>
         <legend.pure.version>5.10.0</legend.pure.version>
         <platform.legend-sdlc.version>0.69.1</platform.legend-sdlc.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Update the legend.engine.version property in the Legend repository to use the latest version of legend-engine (4.73.0).

Link to Devin run: https://app.devin.ai/sessions/c818ca36fe214c508249c26bfa073ce4
Requested by: mauricio.uyaguari@gs.com