### PR TITLE
Add hosted service showcase

### DIFF
--- a/showcases/data/Lambda/Activator - Hosted service/code.pure
+++ b/showcases/data/Lambda/Activator - Hosted service/code.pure
@@ -1,0 +1,43 @@
+###Pure
+function model::greet(name: String[1]): String[1]
+{
+  'Hello, ' + $name + '!'
+}
+
+function model::processData(data: String[1]): String[1]
+{
+  'Processed: ' + $data
+}
+
+###HostedService
+HostedService model::BasicHostedService
+{
+   pattern: '/api/greet/{name}';
+   ownership: UserList { users: [
+      'user1',
+      'user2'
+   ] };
+   function: model::greet(String[1]):String[1];
+   documentation: 'A simple hosted service';
+   autoActivateUpdates: true;
+}
+
+HostedService <<meta::pure::profiles::doc.doc>> {doc.doc = 'Example with deployment ownership'} model::DeploymentHostedService
+{
+   pattern: '/api/process/{data}';
+   ownership: Deployment { identifier: '12345' };
+   function: model::processData(String[1]):String[1];
+   documentation: 'A hosted service with deployment ownership';
+   autoActivateUpdates: false;
+}
+
+HostedService model::AdvancedHostedService
+{
+   pattern: '/api/advanced/{param}';
+   ownership: UserList { users: [
+      'admin'
+   ] };
+   function: model::processData(String[1]):String[1];
+   documentation: 'Advanced hosted service';
+   autoActivateUpdates: true;
+}


### PR DESCRIPTION
# Add hosted service showcase

This PR adds a new showcase project for hosted services in the Legend repository, following the existing showcase project structure.

The showcase includes:
- A `code.pure` file with examples demonstrating hosted service features
- A corresponding `info.md` file documenting the code and its usage

The examples demonstrate:
1. Basic hosted service with UserList ownership
2. Hosted service with Deployment ownership and stereotypes
3. Advanced hosted service with documentation

Link to Devin run: https://app.devin.ai/sessions/7128ec61307945729f6ea205bd493496
Requested by: mauricio.uyaguari@gs.com
