### PR TITLE
Feature/Auto-Update Showcases Dependencies

### DIFF
--- a/.github/workflows/auto-update-showcases-dependencies.yml
+++ b/.github/workflows/auto-update-showcases-dependencies.yml
@@ -1,0 +1,61 @@
+# Copyright 2026 FINOS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Auto-Update Showcases Dependencies
+on:
+  schedule:
+    - cron: "0 1 * * *" # Run daily at 1 AM
+  workflow_dispatch: {}
+
+jobs:
+  update-dependencies:
+    if: github.repository == 'finos/legend'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3.5.2
+        with:
+          token: ${{ secrets.FINOS_GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: "11"
+          distribution: "temurin"
+          cache: "maven"
+
+      - name: Update Showcase Dependencies
+        working-directory: ./showcases
+        run: |
+          mvn versions:use-latest-versions
+
+      - name: Verify Changes
+        working-directory: ./showcases
+        run: |
+          mvn -B test
+
+      - name: Commit and Push Changes
+        run: |
+          if [ -n "$(git status --porcelain showcases/pom.xml)" ]; then
+            git add showcases/pom.xml
+            git commit -m "Update showcase dependencies"
+            git push
+          else
+            echo "No dependency updates found."
+          fi

--- a/showcases/pom.xml
+++ b/showcases/pom.xml
@@ -21,7 +21,7 @@
     </properties>
 
     <dependencies>
-        <!-- TODO: auto-update these on a schedule to make local development easier -->
+
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-extensions-collection-generation</artifactId>


### PR DESCRIPTION
## Auto update Showcases dependencies

Created a new workflow that:

* Runs daily at 1 AM.
* Can be triggered manually via `workflow_dispatch`.
* Automatically executes `mvn versions:use-latest-versions` in the `showcases/` directory.
* Runs `mvn test` to verify that the updates are safe.
* Commits and pushes the updated pom.xml to master if tests pass.